### PR TITLE
Configure Express to serve static frontend build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ backend/data
 
 # Mac system files
 .DS_Store
+
+# Editor settings
+.vscode/

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,12 +6,12 @@ const bookingRoutes = require("./routes/bookingRoutes.js");
 const nominativeRoutes = require("./routes/nominativeRoutes.js");
 const internationalAthleteRoutes = require("./routes/internationalAthleteRoutes.js");
 const accommodationRoutes = require('./routes/accommodationRoutes.js');
-// const path = require('path');
+const path = require('path');
 
 // Connect to MongoDB
 connectDB();
 
-// const __dirname = path.resolve();
+const __dirname = path.resolve();
 const app = express();
 
 // CORS Configuration
@@ -32,21 +32,18 @@ app.use("/api/nominative", nominativeRoutes);
 app.use("/api/international-athletes", internationalAthleteRoutes);
 app.use("/api/accommodations", accommodationRoutes);
 
-// Simple Routes
-app.get('/', (req, res) => res.send('Hello World dhiraj'));
-app.get('/about', (req, res) => res.send('About route 🎉'));
+// Serve frontend
+app.use(express.static(path.join(__dirname, '../frontend/build')));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '../frontend/build', 'index.html'));
+});
 
 // Error Handler
 app.use((err, req, res, next) => {
   console.error(err.stack);
   res.status(500).json({ success: false, message: 'Something broke!' });
 });
-// Serve frontend
-// app.use(express.static(path.join(__dirname, '../frontend/build')));
-
-// app.get('*', (req, res) => {
-//   res.sendFile(path.join(__dirname, '../frontend/build', 'index.html'));
-// });
 
 // Start Server
 app.listen(process.env.PORT, () => {


### PR DESCRIPTION
This PR implements the configuration for Express.js to serve the static frontend build files.

Changes:
- Added configuration for Express to serve static frontend build files
- Enables serving the React frontend directly through the Express backend

The changes will allow the backend to serve the frontend build files, simplifying deployment and serving both frontend and backend from the same origin.